### PR TITLE
Use file-embed to embed path to quivela.smt2 and its content

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -42,6 +42,7 @@ library:
   - -Wno-missed-specialisations # We don't want to add noisy INLINABLE pragmas as we aren't peformance sensitive
   other-modules:
   - Quivela.Prelude
+  - Quivela.Resources
   - Quivela.VerifyPreludes
   - System.Timer
   dependencies:
@@ -53,6 +54,7 @@ library:
   - containers
   - deepseq
   - directory
+  - file-embed
   - filepath
   - lens
   - mtl

--- a/src/Quivela/Resources.hs
+++ b/src/Quivela/Resources.hs
@@ -1,0 +1,22 @@
+-- Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+-- SPDX-License-Identifier: Apache-2.0
+{-# LANGUAGE TemplateHaskell #-}
+
+module Quivela.Resources
+  ( quivelaSmt2Content
+  , quivelaSmt2Path
+  ) where
+
+import Data.FileEmbed (embedStringFile, makeRelativeToProject)
+import Language.Haskell.TH (Exp, Q)
+import Quivela.Prelude
+
+-- | Fully qualified path to quivela.smt2
+quivelaSmt2Path :: Q Exp -- ^ expression
+quivelaSmt2Path = do
+  fullPath <- makeRelativeToProject "src/Quivela/quivela.smt2"
+  [|fullPath|]
+
+-- | Embedded copy of quivela.smt2
+quivelaSmt2Content :: String -- ^ content
+quivelaSmt2Content = $(embedStringFile "src/Quivela/quivela.smt2")

--- a/src/Quivela/Util.hs
+++ b/src/Quivela/Util.hs
@@ -1,29 +1,20 @@
 -- Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 -- SPDX-License-Identifier: Apache-2.0
-{-# LANGUAGE TemplateHaskell #-}
-
 module Quivela.Util
   ( PartialEq((===), elemPartial)
   , foreachM
   , heredoc
   , intercept
-  , readFileCompileTime
   , uncurry3
   ) where
 
-import qualified Control.Monad as Monad
 import qualified Control.Monad.Writer.Class as MonadWriter
 import Control.Monad.Writer.Class (MonadWriter)
 import qualified Data.List as L
 import qualified Language.Haskell.TH as TH
 import Language.Haskell.TH (Exp, Q)
 import qualified Language.Haskell.TH.Quote as TH
-import qualified Language.Haskell.TH.Syntax as TH
 import Quivela.Prelude
-import qualified System.Directory as Directory
-import qualified System.FilePath as FilePath
-import System.FilePath ((</>))
-import qualified System.IO as IO
 
 -- | A type class for types that only support equality partially. Whenever @(a === b) == Just x@,
 -- then the boolean x indicates that a and b are equal/unequal. Otherwise, it cannot be determined
@@ -41,21 +32,6 @@ heredoc :: TH.QuasiQuoter
 heredoc = TH.QuasiQuoter heredocExpr invalidUse invalidUse invalidUse
   where
     invalidUse _ = error "Invalid context for heredoc quasi-quotation"
-
--- | Read file contents at compile time and insert them as a literal expression.
--- the file path is expected to be relative to the current file or an absolute
--- path.
-readFileCompileTime :: FilePath -> Q Exp
-readFileCompileTime inFile = do
-  curFile <- TH.loc_filename <$> TH.location
-  pwd <- TH.runIO Directory.getCurrentDirectory
-  let baseDir = FilePath.takeDirectory $ pwd </> curFile
-      file = baseDir </> inFile
-  exists <- TH.runIO $ Directory.doesFileExist file
-  Monad.unless exists $
-    TH.reportError ("readFileCompileTime: No such file: " ++ file)
-  TH.addDependentFile file
-  TH.runIO (IO.readFile file) >>= heredocExpr
 
 foreachM :: (Monad m) => m [a] -> (a -> m [b]) -> m [b]
 foreachM s act = do

--- a/src/Quivela/VerifyPreludes.hs
+++ b/src/Quivela/VerifyPreludes.hs
@@ -8,7 +8,7 @@ module Quivela.VerifyPreludes
   ) where
 
 import Quivela.Prelude
-import qualified Quivela.Util as Q
+import Quivela.Resources (quivelaSmt2Content, quivelaSmt2Path)
 import qualified System.IO as IO
 
 -- This file defines the preludes for the z3 backend so we don't
@@ -16,7 +16,7 @@ import qualified System.IO as IO
 -- files somewhere)
 -- | Z3 encoding for quivela values and operations on them
 z3Prelude :: IO String
-z3Prelude = IO.readFile "src/Quivela/quivela.smt2"
+z3Prelude = IO.readFile $quivelaSmt2Path
 
-z3PreludeCompiled :: (Monad m) => m String
-z3PreludeCompiled = return $(Q.readFileCompileTime "quivela.smt2")
+z3PreludeCompiled :: String
+z3PreludeCompiled = quivelaSmt2Content


### PR DESCRIPTION
[file-embed](http://hackage.haskell.org/package/file-embed) has helpers for embedding file contents into executables and for resolving paths relative to the current project root to absolute paths. This allows users to run `stack ghci` from within the `examples` directory without the program erroring out because it can't load `src/Quivela/quivela.smt2`.
