### PR TITLE
Convert README to Literate Haskell file so that syntax can be verified as part of test suite

### DIFF
--- a/README.lhs
+++ b/README.lhs
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -17,18 +17,29 @@ Linux/Mac systems).
 
 ## Usage
 
-`quivela2` proofs are developed in a Haskell file that imports `quivela2` as a
-library. To prove programs equivalent, we construct a series of proof steps as a
-Haskell expression and then invoke the verifier on it; here is a small example
-that shows that the `&` operator commutes (aside from the value it returns) and
-that `1 & x` is equivalent to `x`.
+**Note that this document is a [Literate Haskell][literate-haskell] source file that you can compile and run as follows:**
 
+```bash
+stack test quivela:readme
 ```
-{-# LANGUAGE TemplateHaskell, QuasiQuotes #-}
-module Quivela.Examples where
+
+Quivela2 proofs are developed in a Haskell source file that imports various Quivela2 modules and compiles against the `quivela` library. Proof sources will typically require both the `QuasiQuotes` and `TemplateHaskell` language extensions to be enabled and the `Quivela` and `Quivela.Language` modules to be imported. The `System.Exit` module can also be imported for later use in the `main` function:
+
+```haskell
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Main (main) where
 
 import Quivela
+import Quivela.Language
+import System.Exit
+```
 
+To prove programs equivalent, we construct a series of proof steps as a
+Haskell expression and then invoke the verifier on it; here is a small example that shows that the `&` operator commutes (aside from the value it returns) and that `1 & x` is equivalent to `x`:
+
+```haskell
 andExample :: [ProofPart]
 andExample =
   [prog| new() { method f(x, y) { 1 & x & y & 1 } } |]
@@ -39,26 +50,19 @@ andExample =
   : []
 ```
 
-Quivela programs are embedded into Haskell using the `prog` quasiquotation,
-which expands into parsing the given Quivela expression. The `≈` operator chains
-together several expressions. Since proofs are represented as lists, each proof
-must be terminated by `: []`.
+Quivela2 programs are embedded into Haskell using the `prog` quasiquotation, which expands into parsing the given Quivela2 expression. The `≈` operator chains together several expressions. Since proofs are represented as lists, each proof must be terminated by `: []`.
 
-To check this proof, load the file in `GHCi` and evaluate
+To check this proof, load the file in `GHCi` and evaluate the following expression:
 
-```prove' emptyVerifyEnv nop andExample```
-
-The `prove'` function takes an environment as the first argument (usually 
-`emptyVerifyEnv` if starting from scratch), an expression containing shared method definitions
-and global variable declarations as the second argument and a list of `ProofPart`s
-as the third argument.
-
-To avoid having to manually evaluate a call to `prove'` after each modification,
-`quivela2` also provides a compile-time version called `prove` that will perform
-the verification as part of loading the file in GHCi. The proof above
-can then be written as follows:
-
+```.haskell .ignore
+prove' emptyVerifyEnv nop andExample
 ```
+
+The `prove'` function takes an environment as the first argument (usually `emptyVerifyEnv` if starting from scratch), an expression containing shared method definitions and global variable declarations as the second argument and a list of `ProofPart`s as the third argument.
+
+To avoid having to manually evaluate a call to `prove'` after each modification, Quivela2 also provides a compile-time version called `prove` that will perform the verification as part of loading the file in GHCi. The proof above can then be written as follows:
+
+```haskell
 prove emptyVerifyEnv nop $
   [prog| new() { method f(x, y) { 1 & x & y & 1 } } |]
   ≈
@@ -68,11 +72,9 @@ prove emptyVerifyEnv nop $
   : []
 ```
 
-Some steps may require additional proof hints. For example, to prove objects
-with mutable fields equivalent, it is often necessary to state an appropriate
-invariant:
+Some steps may require additional proof hints. For example, to prove objects with mutable fields equivalent, it is often necessary to state an appropriate invariant:
 
-```
+```haskell
 eqInvExample :: [ProofPart]
 eqInvExample =
   [prog| new (x=0) { method f() { <x, x> } } |]
@@ -81,20 +83,32 @@ eqInvExample =
   : []
 ```
 
-Instead of stating many equality invariants on variables that are never
-modified, object fields can be declared as constant:
+Instead of stating many equality invariants on variables that are never modified, object fields can be declared as constant:
 
-```
-prove emptyVerifyEnv nop
+```haskell
+prove emptyVerifyEnv nop $
   [prog| new (const x=0) { method f() { x } } |]
   ≈
   [prog| new (const x=0) { method f() { 0 } } |]
-  :[]
+  : []
 ```
 
-For a larger proof, please refer to <src/Quivela/Examples/ETM.hs>.
+Multiple proofs can be run from the `main` function:
+
+```haskell
+main :: IO ()
+main = do
+  andResult <- prove' emptyVerifyEnv nop andExample
+  eqInvResult <- prove' emptyVerifyEnv nop eqInvExample
+  if andResult /= 0 || eqInvResult /= 0
+    then exitFailure
+    else exitSuccess
+```
+
+For a larger proof, please refer to [`ETM.hs`](src/ETM.hs).
 
 ## Open issues
+
 There are number of side conditions that are currently not checked:
 
 - Programs are not checked for termination
@@ -121,3 +135,5 @@ There are number of side conditions that are currently not checked:
 
 - Either import by name or qualify all imported identifiers.
 - Run hindent (we use all default settings) before creating pull request.
+
+[literate-haskell]: https://wiki.haskell.org/Literate_programming

--- a/package.yaml
+++ b/package.yaml
@@ -112,3 +112,12 @@ tests:
     main: examples/FIFOSmall.hs
     dependencies:
     - quivela
+  readme:
+    main: README.lhs
+    dependencies:
+    - base
+    - markdown-unlit
+    - quivela
+    ghc-options: -pgmL markdown-unlit
+    default-extensions:
+    - ImplicitPrelude


### PR DESCRIPTION
I noticed that some of the examples in `README.md` did not compile. This change fixes up the examples and adds a new `readme` test suite that will build and run `README.md` as a Literate Haskell source file so that we can detect if the examples become invalid (this requires the `README.lhs` symlink to function). Converting the file to a buildable Literate Haskell source requires that we name the module `Main` and export a `main` function. I think this is a sacrifice worth making!
